### PR TITLE
Add Springdoc OpenAPI UI dependency to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ configure(subprojects.findAll { return true }) {
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
 
         runtimeOnly 'org.postgresql:postgresql'
 


### PR DESCRIPTION
This commit adds the 'springdoc-openapi-ui' dependency to the project's build.gradle file. This will enable the generation of API documentation and provide a user interface for the API testing.