### PR TITLE
Update Dockerfiles to use openjdk:11.0.21-jre

### DIFF
--- a/database_per_services/private_table_per_service/customer_service/Dockerfile
+++ b/database_per_services/private_table_per_service/customer_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jre
+FROM openjdk:11.0.21-jre
 
 
 RUN useradd --create-home customer_service

--- a/database_per_services/private_table_per_service/order_service/Dockerfile
+++ b/database_per_services/private_table_per_service/order_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jre
+FROM openjdk:11.0.21-jre
 
 
 RUN useradd --create-home order_service

--- a/shared_database/customer_service/Dockerfile
+++ b/shared_database/customer_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jre
+FROM openjdk:11.0.21-jre
 
 
 RUN useradd --create-home customer_service

--- a/shared_database/order_service/Dockerfile
+++ b/shared_database/order_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jre
+FROM openjdk:11.0.21-jre
 
 
 RUN useradd --create-home order_service


### PR DESCRIPTION
Upgraded the base image in Dockerfiles from openjdk:11.0.16-jre to openjdk:11.0.21-jre in various service directories. This change aims to improve application security and feature availability by utilizing the latest Java runtime environment.