### PR TITLE
Update Spring dependency management version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.15'
-    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 


### PR DESCRIPTION
The version for 'io.spring.dependency-management' in build.gradle has been updated from '1.0.15.RELEASE' to '1.1.4'. This is a necessary step to keep the project up-to-date with the latest improvements and bug fixes provided by this Spring plugin.