### PR TITLE
Add Docker build steps for event_sourcing images

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -78,3 +78,19 @@ jobs:
           file: ./shared_database/db/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:shared_database
+
+      - name: Build event_sourcing consumer image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./event_sourcing/consumer
+          file: /event_sourcing/consumer/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:event_sourcing.consumer
+
+      - name: Build event_sourcing producer image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./event_sourcing/producer
+          file: /event_sourcing/producer/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:event_sourcing.producer


### PR DESCRIPTION
Modified the GitHub workflow to include Docker build and push steps for both the event_sourcing consumer and producer images. The respective Dockerfiles are used to create these images, which will facilitate continuous deployment processes.