### PR TITLE
Correct Dockerfile paths in GitHub workflow

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./event_sourcing/consumer
-          file: /event_sourcing/consumer/Dockerfile
+          file: ./event_sourcing/consumer/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:event_sourcing.consumer
 
@@ -91,6 +91,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./event_sourcing/producer
-          file: /event_sourcing/producer/Dockerfile
+          file: ./event_sourcing/producer/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:event_sourcing.producer


### PR DESCRIPTION
Updated the paths for Dockerfile in the Github docker-build-image workflow. This change ensures that the Docker build and push steps correctly reference the Dockerfiles for the event_sourcing consumer and producer images. The updated paths align with the directory structure of the project for uninterrupted CI/CD execution.