### PR TITLE
Add .run to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ build
 /shared_database/db/.idea/workspace.xml
 /shared_database/order_service/.idea/workspace.xml
 /.idea/
+.run


### PR DESCRIPTION
Modified the .gitignore file to include .run, ignoring any files with this extension. This reduces unnecessary clutter in the repository and prevents accidental upload of these typically transient and unneeded files.