### PR TITLE
Update Docker build context in GitHub Actions

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Build event_sourcing consumer image
         uses: docker/build-push-action@v5
         with:
-          context: ./event_sourcing/consumer
+          context: ./messaging/consumer/
           file: ./messaging/consumer/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:messaging.consumer


### PR DESCRIPTION
The Docker context path in the GitHub Actions workflow for building image has been updated. The context was incorrect, causing a failure in the build and push action. Now, it's been corrected to point to the Dockerfile in the messaging/consumer directory from the project root.