### PR TITLE
Update Spring Boot version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.15'
+    id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 


### PR DESCRIPTION
The Spring Boot version in the build.gradle file has been updated from '2.7.15' to '2.7.18'. This commit ensures our application uses the most recent and secure version of Spring Boot, simplifying maintenance and potentially improving performance.