### PR TITLE
Remove mavenCentral() from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,6 @@ allprojects {
     java {
         sourceCompatibility = '11'
     }
-
-    repositories {
-        mavenCentral()
-    }
     
 }
 


### PR DESCRIPTION
This change removes the mavenCentral() from the build.gradle file. The program previously attempted to fetch dependencies from Maven Central, but this step is no longer required which simplifies the build process.