### PR TITLE
Remove upload step for graphql@gateway in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,16 +134,6 @@ jobs:
             ./messaging/graphql/gateway/*.sh
             ./messaging/graphql/gateway/Dockerfile
 
-      - name: Upload graphql@gateway
-        uses: actions/upload-artifact@v4
-        with:
-          name: graphql@gateway
-          path: |
-            ./messaging/graphql/gateway/build/libs/*.jar
-            ./messaging/graphql/gateway/*.env
-            ./messaging/graphql/gateway/*.sh
-            ./messaging/graphql/gateway/Dockerfile
-
       - name: Upload circuit_breaker@proxy
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@ My practice of writing codes following microservice patterns
 **Main branch:**
 
 [![Build project](https://github.com/nawaphonOHM/microservice-play/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/nawaphonOHM/microservice-play/actions/workflows/main.yml)
-
-[![docker build image](https://github.com/nawaphonOHM/microservice-play/actions/workflows/docker-build-image.yml/badge.svg?branch=main)](https://github.com/nawaphonOHM/microservice-play/actions/workflows/docker-build-image.yml)


### PR DESCRIPTION
Removed the steps that upload the graphql@gateway artifact from the Github Actions workflow. This step was redundant as the artifact was not required in subsequent workflow steps.