### PR TITLE
Update GitHub workflow to use setup-gradle action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
 
       - name: Run the Gradle package task
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: build
 


### PR DESCRIPTION
The Gradle build action has been replaced with the setup-gradle action in the GitHub workflow. This change will allow us to maintain consistency and standardize our setup process.