### PR TITLE
Update gradle action in GitHub workflow

### DIFF
--- a/.github/workflows/request-merge-to-main.yml
+++ b/.github/workflows/request-merge-to-main.yml
@@ -27,6 +27,6 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
 
       - name: Run the Gradle package task
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: build


### PR DESCRIPTION
In the GitHub Actions workflow, the Gradle build action has been replaced with the Setup Gradle action. This aims at improving build procedures. The changes have been applied in the request-merge-to-main.yml file.