### PR TITLE
Update GitHub Action for Gradle setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,11 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v3
 
-      - name: Run the Gradle package task
+      - name: Setup gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: build
+
+      - name: Run the Gradle package task
+        run: ./gradlew build
 
       - name: Upload private_table_per_service@customer_service
         uses: actions/upload-artifact@v4

--- a/.github/workflows/request-merge-to-main.yml
+++ b/.github/workflows/request-merge-to-main.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v3
 
-      - name: Run the Gradle package task
+      - name: Setup gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: build
+
+      - name: Run the Gradle package task
+        run: ./gradlew build


### PR DESCRIPTION
The GitHub Action workflow for Gradle has been updated. Initially, the workflow was incorrectly executing the Gradle package task. Now, it has been modified to first set up Gradle using an official Gradle setup action before running the Gradle build task.