### PR TITLE
Fix typos in workflow artifact names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -491,10 +491,10 @@ jobs:
     needs: build-jar
     runs-on: ubuntu-latest
     steps:
-      - name: Download service_registry@self_registrstion
+      - name: Download service_registry@self_registration
         uses: actions/download-artifact@v4
         with:
-          name: service_registry@self_registrstion
+          name: service_registry@self_registration
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -517,10 +517,10 @@ jobs:
     needs: build-jar
     runs-on: ubuntu-latest
     steps:
-      - name: Download serviceA@self_registrstion
+      - name: Download serviceA@self_registration
         uses: actions/download-artifact@v4
         with:
-          name: serviceA@self_registrstion
+          name: serviceA@self_registration
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Corrected the spelling of 'self_registration' in multiple steps within the GitHub Actions workflow file. This ensures accurate naming and proper artifact handling during the CI process.