### PR TITLE
Add workflow for serviceA in server-side discovery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,6 +204,16 @@ jobs:
             ./client_side_discovery/client/*.sh
             ./client_side_discovery/client/Dockerfile
             ./client_side_discovery/client/build/libs/*.jar
+
+      - name: Upload serviceA@server_side_discovery
+        uses: actions/upload-artifact@v4
+        with:
+          name: serviceA@server_side_discovery
+          path: |
+            ./server_side_discovery/serviceA/*.env
+            ./server_side_discovery/serviceA/*.sh
+            ./server_side_discovery/serviceA/Dockerfile
+            ./server_side_discovery/serviceA/build/libs/*.jar
       
             
 
@@ -648,3 +658,29 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:client-side-discovery.services-registry
+
+  push-image-service-A-server-side-discovery:
+    needs: build-jar
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download serviceA@server_side_discovery
+        uses: actions/download-artifact@v4
+        with:
+          name: serviceA@server_side_discovery
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:server-side-discovery.serviceA


### PR DESCRIPTION
Introduce a new GitHub Action workflow to handle serviceA artifacts and Docker image creation for the server-side discovery module. This includes uploading relevant artifacts, downloading them for the image build, and pushing the image to Docker Hub.