### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build-jar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nawaphonOHM/microservice-play/security/code-scanning/22](https://github.com/nawaphonOHM/microservice-play/security/code-scanning/22)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for the workflow to function correctly. Since the workflow primarily interacts with external services and downloads artifacts, it likely only requires `contents: read`. We will add this `permissions` block at the root level of the workflow to apply it to all jobs. If any job requires additional permissions, we will define them specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
