### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/request-merge-to-main.yml
+++ b/.github/workflows/request-merge-to-main.yml
@@ -9,6 +9,8 @@ on:
       - synchronize
     branches:
       - 'main'
+permissions:
+  contents: read
 jobs:
   build-check-for-merge-request:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nawaphonOHM/microservice-play/security/code-scanning/2](https://github.com/nawaphonOHM/microservice-play/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow performs basic CI tasks like code checkout and build validation, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` has limited access, adhering to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow. Alternatively, it can be added specifically to the `build-check-for-merge-request` job. For simplicity and clarity, the root-level approach is recommended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
