### PR TITLE
Update health check script to use HTTP status code

### DIFF
--- a/transactional_outbox_pattern/transaction_log_tailing/order_service/healthy_check.sh
+++ b/transactional_outbox_pattern/transaction_log_tailing/order_service/healthy_check.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 
-RESULT=$(curl 'http://localhost:8080/transactional_outbox_pattern/order-service/actuator/health' -s -i -X GET -H \
-'Accept: application/json' | grep -Eo '\{\"status\":\"([A-Z]+)\"\}' | sed -E 's/\{\"status\":\"([A-Z]+)\"\}/\1/')
+RESULT=$(curl 'http://localhost:8080/transactional_outbox_pattern/order-service/actuator/health' -o /dev/null -w "%{http_code}" \
+-s -i -X GET )
 
-if [ "$RESULT" != "UP" ]; then
+if [ "$RESULT" != "200" ]; then
   exit 1
 fi
 


### PR DESCRIPTION
Revised the health check script to validate service availability by checking for "200" HTTP status code instead of analyzing the JSON response. Simplifies and optimizes the script's logic.