### PR TITLE
Update Kafka advertised listener in Docker Compose

### DIFF
--- a/transactional_outbox_pattern/transaction_log_tailing/docker-compose.yml
+++ b/transactional_outbox_pattern/transaction_log_tailing/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   kafka:
     image: ubuntu/kafka:latest
-    command: [ "/etc/kafka/server.properties", "--override", "advertised.listeners=PLAINTEXT://192.168.1.3:9092" ]
+    command: [ "/etc/kafka/server.properties", "--override", "advertised.listeners=PLAINTEXT://kafka:9092" ]
     env_file: ./kafka/kafka.env
     ports:
       - "9092:9092"


### PR DESCRIPTION
Modified `advertised.listeners` in Kafka service to use `kafka:9092` instead of a specific IP. This improves portability and ensures compatibility across environments.