### PR TITLE
Update Kafka advertised listener in Docker Compose

### DIFF
--- a/messaging/event_sourcing/compose.yaml
+++ b/messaging/event_sourcing/compose.yaml
@@ -10,7 +10,7 @@ services:
 
   kafka_0:
     image: ubuntu/kafka:latest
-    command: [ "/etc/kafka/server.properties", "--override", "advertised.listeners=PLAINTEXT://192.168.1.3:9092" ]
+    command: [ "/etc/kafka/server.properties", "--override", "advertised.listeners=PLAINTEXT://kafka_0:9092" ]
     env_file:
       - kafka/kafka-vars.env
     ports:


### PR DESCRIPTION
Modified `advertised.listeners` for Kafka service to use `kafka_0:9092` instead of a hardcoded IP. This improves portability and ensures compatibility across environments.