### PR TITLE
Fix null assignment issue in ToHashMapModel utility

### DIFF
--- a/transactional_outbox_pattern/transaction_log_tailing/order_service/src/main/java/nawaphon/microservices/transactional_outbox_pattern/order_service/utils/ToHashMapModel.java
+++ b/transactional_outbox_pattern/transaction_log_tailing/order_service/src/main/java/nawaphon/microservices/transactional_outbox_pattern/order_service/utils/ToHashMapModel.java
@@ -18,19 +18,20 @@ public final class ToHashMapModel {
 
         for (final Field field : object.getClass().getDeclaredFields()) {
             final String key = field.getName();
+            final Object value;
 
             try {
-                final Object value = object.getClass()
+                value = object.getClass()
                         .getDeclaredMethod("get" + key.substring(0, 1).toUpperCase() + key.substring(1))
                         .invoke(object);
-
-                map.put(key, value);
 
 
             } catch (final IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                 log.error("Unable to convert object to map", e);
                 throw new ToHashMpModelException(e);
             }
+
+            map.put(key, value);
 
         }
 


### PR DESCRIPTION
Resolved an issue where the `value` variable was declared outside the try block but assigned within it, causing potential null assignments. Adjusted `map.put()` call placement to ensure proper handling of the `value`.