### PR TITLE
Upgrade dependencies and refactor `GrpcService`:

### DIFF
--- a/client_side_discovery/client/build.gradle
+++ b/client_side_discovery/client/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+    implementation 'org.springframework.boot:spring-boot-starter-restclient'
+
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
-springCloudVersion=2025.1.1
-springGrpcVersion=1.0.2
-springBootVersion=4.0.6
-springBootStarterAop=3.5.14
+springCloudVersion=2025.1.2
+springBootVersion=4.1.0
+springBootStarterAop=3.5.15
 springBootDependencyManagement=1.1.7
-protobufPluginVersion=0.9.5
+protobufPluginVersion=0.9.6
 javaVersion=21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/messaging/grpc/client/build.gradle
+++ b/messaging/grpc/client/build.gradle
@@ -13,17 +13,18 @@ base {
 }
 
 protobuf {
-    protoc {
-        def s = dependencyManagement.importedProperties['protobuf-java.version']
+    def protobufVersion = dependencyManagement.importedProperties['protobuf-java.version']
+    def grpcVersion = dependencyManagement.importedProperties['grpc-java.version']
 
-        artifact = "com.google.protobuf:protoc:${s}"
+    protoc {
+
+        artifact = "com.google.protobuf:protoc:${protobufVersion}"
     }
     plugins {
-        def object = dependencyManagement.importedProperties['grpc-java.version']
 
         grpc {
 
-            artifact = "io.grpc:protoc-gen-grpc-java:${object}"
+            artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
         }
     }
 }

--- a/messaging/grpc/client/build.gradle
+++ b/messaging/grpc/client/build.gradle
@@ -12,39 +12,30 @@ base {
     archivesName = "client"
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.grpc:spring-grpc-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.grpc:spring-grpc-dependencies:" + springGrpcVersion
-    }
-}
-
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc'
+        def s = dependencyManagement.importedProperties['protobuf-java.version']
+
+        artifact = "com.google.protobuf:protoc:${s}"
     }
     plugins {
+        def object = dependencyManagement.importedProperties['grpc-java.version']
+
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java'
+
+            artifact = "io.grpc:protoc-gen-grpc-java:${object}"
         }
     }
-    generateProtoTasks {
-        all()*.plugins {
-            grpc {
-                option '@generated=omit'
-            }
-        }
-    }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-grpc-client'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-grpc-client-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {

--- a/messaging/grpc/client/src/main/java/nawaphon/microservices/messaging/grpc/client/GrpcClientApplication.java
+++ b/messaging/grpc/client/src/main/java/nawaphon/microservices/messaging/grpc/client/GrpcClientApplication.java
@@ -2,8 +2,10 @@ package nawaphon.microservices.messaging.grpc.client;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.grpc.client.ImportGrpcClients;
 
 @SpringBootApplication
+@ImportGrpcClients
 public class GrpcClientApplication {
 
     public static void main(String[] args) {

--- a/messaging/grpc/client/src/main/proto/server.proto
+++ b/messaging/grpc/client/src/main/proto/server.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = 'nawaphon.microservices.messaging.grpc.client';
-option java_outer_classname = 'ServerProto';
 
 
 message UUID {

--- a/messaging/grpc/server/build.gradle
+++ b/messaging/grpc/server/build.gradle
@@ -12,39 +12,31 @@ base {
     archivesName = "server"
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.grpc:spring-grpc-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.grpc:spring-grpc-dependencies:" + springGrpcVersion
-    }
-}
-
 protobuf {
+    def protobufVersion = dependencyManagement.importedProperties['protobuf-java.version']
+    def grpcVersion = dependencyManagement.importedProperties['grpc-java.version']
+
     protoc {
-        artifact = 'com.google.protobuf:protoc'
+
+        artifact = "com.google.protobuf:protoc:${protobufVersion}"
     }
     plugins {
+
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java'
+
+            artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
         }
     }
-    generateProtoTasks {
-        all()*.plugins {
-            grpc {
-                option '@generated=omit'
-            }
-        }
-    }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-grpc-server'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-grpc-server-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {

--- a/messaging/grpc/server/src/main/java/nawaphon/microservices/messaging/grpc/server/components/GrpcServerService.java
+++ b/messaging/grpc/server/src/main/java/nawaphon/microservices/messaging/grpc/server/components/GrpcServerService.java
@@ -8,18 +8,18 @@ import nawaphon.microservices.messaging.grpc.server.UUID;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.grpc.server.service.GrpcService;
 
 import java.util.NoSuchElementException;
 
 
-@Component
-class GrpcService extends MainServerGrpc.MainServerImplBase {
+@GrpcService
+class GrpcServerService extends MainServerGrpc.MainServerImplBase {
 
-    private static final Logger log = LoggerFactory.getLogger(GrpcService.class);
+    private static final Logger log = LoggerFactory.getLogger(GrpcServerService.class);
     private final FakeDatabaseComponent fakeDatabaseComponent;
 
-    GrpcService(FakeDatabaseComponent fakeDatabaseComponent) {
+    GrpcServerService(FakeDatabaseComponent fakeDatabaseComponent) {
         this.fakeDatabaseComponent = fakeDatabaseComponent;
     }
 

--- a/messaging/grpc/server/src/main/proto/server.proto
+++ b/messaging/grpc/server/src/main/proto/server.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = 'nawaphon.microservices.messaging.grpc.server';
-option java_outer_classname = 'ServerProto';
 
 
 message UUID {


### PR DESCRIPTION
- Replace `@Component` with `@GrpcService` annotation, rename class to `GrpcServerService`, and update logger references.
- Update Gradle properties: `springBootVersion`, `springBootStarterAop`, and `protobufPluginVersion`.
- Upgrade Gradle wrapper to 9.5.1.
- Refactor and streamline Gradle build configurations for gRPC projects.
- Add `restclient` dependency to `client_side_discovery`.
- Refactor gRPC client with `@ImportGrpcClients` annotation.