### PR TITLE
Update Docker workflow: rename image tag

### DIFF
--- a/.github/workflows/every_night_push_image_into_docker_repository.yml
+++ b/.github/workflows/every_night_push_image_into_docker_repository.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   push_image:
-    name: Download and Push /microservice-using-docker-build:${{inputs.image_name_for_docker_hub}} image into docker hub
+    name: Download and Push microservice-using-docker-build:${{inputs.image_name_for_docker_hub}} image into docker hub
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/every_night_push_image_into_docker_repository.yml
+++ b/.github/workflows/every_night_push_image_into_docker_repository.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   push_image:
-    name: Download and Push <docker-repo-name>/microservices-lab:${{inputs.image_name_for_docker_hub}} image into docker hub
+    name: Download and Push /microservice-using-docker-build:${{inputs.image_name_for_docker_hub}} image into docker hub
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,4 +41,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/microservices-lab:${{inputs.image_name_for_docker_hub}}
+          tags: ${{ secrets.DOCKER_USERNAME }}/microservice-using-docker-build:${{inputs.image_name_for_docker_hub}}

--- a/circuit_breaker/compose.yaml
+++ b/circuit_breaker/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   proxy:
-    image: nawaphon2539/microservices-lab:circuit-breaker.proxy
+    image: nawaphon2539/microservice-using-docker-build:circuit-breaker.proxy
     env_file:
       - proxy/proxy-vars.env
     ports:
@@ -11,7 +11,7 @@ services:
         ipv4_address: 192.168.10.2
 
   real_service:
-    image: nawaphon2539/microservices-lab:circuit-breaker.real-service
+    image: nawaphon2539/microservice-using-docker-build:circuit-breaker.real-service
     env_file:
       - real_service/real_service-vars.env
     ports:

--- a/client_side_discovery/compose.yaml
+++ b/client_side_discovery/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   servicesRegistry:
-    image: nawaphon2539/microservices-lab:client-side-discovery.services-registry
+    image: nawaphon2539/microservice-using-docker-build:client-side-discovery.services-registry
     env_file:
       - services_registry/services-registry-vars.env
     ports:
@@ -10,7 +10,7 @@ services:
       default:
 
   service_a:
-    image: nawaphon2539/microservices-lab:client-side-discovery.serviceA
+    image: nawaphon2539/microservice-using-docker-build:client-side-discovery.serviceA
     env_file:
       - serviceA/service-a-vars.env
     ports:
@@ -22,7 +22,7 @@ services:
       replicas: 4
 
   client:
-    image: nawaphon2539/microservices-lab:client-side-discovery.client
+    image: nawaphon2539/microservice-using-docker-build:client-side-discovery.client
     env_file:
       - client/client-vars.env
     ports:

--- a/database_per_services/private_table_per_service/compose.yaml
+++ b/database_per_services/private_table_per_service/compose.yaml
@@ -1,6 +1,6 @@
 services:
   order-service:
-    image: nawaphon2539/microservices-lab:private-table-per-service.order-service
+    image: nawaphon2539/microservice-using-docker-build:private-table-per-service.order-service
     ports:
       - "1000:8080"
     env_file:
@@ -10,7 +10,7 @@ services:
         ipv4_address: 192.168.1.2
     depends_on: [database]
   customer-service:
-    image: nawaphon2539/microservices-lab:private-table-per-service.customer-service
+    image: nawaphon2539/microservice-using-docker-build:private-table-per-service.customer-service
     ports:
       - "1001:8080"
     env_file:
@@ -20,7 +20,7 @@ services:
         ipv4_address: 192.168.1.3
     depends_on: [database]
   database:
-    image: nawaphon2539/microservices-lab:private-table-per-service
+    image: nawaphon2539/microservice-using-docker-build:private-table-per-service
     env_file:
       - db/database-vars.env
     networks:

--- a/messaging/event_sourcing/compose.yaml
+++ b/messaging/event_sourcing/compose.yaml
@@ -21,7 +21,7 @@ services:
     depends_on: [ zookeeper ]
 
   producer_0:
-    image: nawaphon2539/microservices-lab:messaging.event_sourcing.producer
+    image: nawaphon2539/microservice-using-docker-build:messaging.event_sourcing.producer
     env_file:
       - producer/producer-vars.env
     ports:
@@ -32,7 +32,7 @@ services:
     depends_on: [ kafka_0 ]
 
   consumer_0:
-    image: nawaphon2539/microservices-lab:messaging.event_sourcing.consumer
+    image: nawaphon2539/microservice-using-docker-build:messaging.event_sourcing.consumer
     env_file:
       - consumer/consumer-vars.env
     ports:

--- a/messaging/graphql/compose.yaml
+++ b/messaging/graphql/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   gateway:
-    image: nawaphon2539/microservices-lab:messaging.graphql.gateway
+    image: nawaphon2539/microservice-using-docker-build:messaging.graphql.gateway
     env_file:
       - gateway/gateway-vars.env
     ports:

--- a/messaging/grpc/compose.yaml
+++ b/messaging/grpc/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   client:
-    image: nawaphon2539/microservices-lab:messaging.grpc.client
+    image: nawaphon2539/microservice-using-docker-build:messaging.grpc.client
     env_file:
       - client/client-vars.env
     ports:
@@ -11,7 +11,7 @@ services:
         ipv4_address: 192.168.1.2
 
   server:
-    image: nawaphon2539/microservices-lab:messaging.grpc.server
+    image: nawaphon2539/microservice-using-docker-build:messaging.grpc.server
     env_file:
       - server/server-vars.env
     ports:

--- a/messaging/rest/compose.yaml
+++ b/messaging/rest/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   receiver:
-    image: nawaphon2539/microservices-lab:messaging.rest.receiver
+    image: nawaphon2539/microservice-using-docker-build:messaging.rest.receiver
     env_file:
       - receiver/receiver-vars.env
     ports:
@@ -11,7 +11,7 @@ services:
         ipv4_address: 192.168.1.2
 
   sender:
-    image: nawaphon2539/microservices-lab:messaging.rest.sender
+    image: nawaphon2539/microservice-using-docker-build:messaging.rest.sender
     env_file:
       - sender/sender-vars.env
     ports:

--- a/self_registration/compose.yaml
+++ b/self_registration/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   servicesRegistry:
-    image: nawaphon2539/microservices-lab:self-registration.services-registry
+    image: nawaphon2539/microservice-using-docker-build:self-registration.services-registry
     env_file:
       - services_registry/services-registry-vars.env
     ports:
@@ -10,7 +10,7 @@ services:
       default:
 
   service_a:
-    image: nawaphon2539/microservices-lab:self-registration.services-a
+    image: nawaphon2539/microservice-using-docker-build:self-registration.services-a
     env_file:
       - serviceA/service-a-vars.env
     ports:

--- a/server_side_discovery/serviceA/serviceA-deployment.yaml
+++ b/server_side_discovery/serviceA/serviceA-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: server-side-discovery-and-service-a
-          image: nawaphon2539/microservices-lab:server_side_discovery.serviceA
+          image: nawaphon2539/microservice-using-docker-build:server_side_discovery.serviceA
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/shared_database/compose.yaml
+++ b/shared_database/compose.yaml
@@ -1,6 +1,6 @@
 services:
   order-service:
-    image: nawaphon2539/microservices-lab:shared-database.order-service
+    image: nawaphon2539/microservice-using-docker-build:shared-database.order-service
     ports:
       - "1000:8080"
     env_file:
@@ -10,7 +10,7 @@ services:
         ipv4_address: 192.168.1.2
     depends_on: [ database ]
   customer-service:
-    image: nawaphon2539/microservices-lab:shared-database.customer-service
+    image: nawaphon2539/microservice-using-docker-build:shared-database.customer-service
     ports:
       - "1001:8080"
     env_file:
@@ -20,7 +20,7 @@ services:
         ipv4_address: 192.168.1.3
     depends_on: [ database ]
   database:
-    image: nawaphon2539/microservices-lab:shared-database
+    image: nawaphon2539/microservice-using-docker-build:shared-database
     env_file:
       - db/database-vars.env
     networks:

--- a/transactional_outbox_pattern/transaction_log_tailing/compose.yml
+++ b/transactional_outbox_pattern/transaction_log_tailing/compose.yml
@@ -12,7 +12,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
 
   order:
-    image: nawaphon2539/microservices-lab:transactional_outbox_pattern.transaction_log_tailing.order_service
+    image: nawaphon2539/microservice-using-docker-build:transactional_outbox_pattern.transaction_log_tailing.order_service
     env_file: ./order_service/order_service.env
     ports:
       - "1002:8080"


### PR DESCRIPTION
Updated the Docker GitHub Actions workflow to rename the image tag to `/microservice-using-docker-build`. This change ensures consistency with the naming convention and improves clarity for identifying Docker images.